### PR TITLE
Provide an absolute path for including settings.php

### DIFF
--- a/export.php
+++ b/export.php
@@ -33,7 +33,7 @@ Updates:
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-include('settings.php');
+include( plugin_dir_path( __FILE__ ) . 'settings.php' );
 
 /* Define the custom box */
 add_action('admin_init', 'dirtysuds_export_html_box', 1);


### PR DESCRIPTION
Including just `settings.php` causes PHP to include `wp-admin/network/settings.php` when viewing the Network Admin on a Multisite install, resulting in an `E_FATAL`
